### PR TITLE
refactor: specialize RecordUpdateField comment handling

### DIFF
--- a/src/HIndent/Ast/Expression/RecordUpdateField.hs
+++ b/src/HIndent/Ast/Expression/RecordUpdateField.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Expression.RecordUpdateField
@@ -87,38 +86,77 @@ prettyFieldVertical Field {..} = do
     string " ="
     (space >> pretty val) <-|> (newline >> indentedBlock (pretty val))
 
-collectFieldsWith ::
-     CommentExtraction (GHC.Anno label)
-  => (label -> FieldName)
-  -> [GHC.LocatedA
-        (GHC.HsFieldBind (GHC.XRec GHC.GhcPs label) (GHC.LHsExpr GHC.GhcPs))]
-  -> [WithComments Field]
-collectFieldsWith mkLabel =
-  fmap (fmap (mkField (fmap mkLabel . fromGenLocated)) . fromGenLocated)
-
 collectFields :: GHC.LHsRecUpdFields GHC.GhcPs -> [WithComments Field]
 #if MIN_VERSION_ghc_lib_parser(9, 12, 1)
 collectFields GHC.RegularRecUpdFields {..} =
-  collectFieldsWith mkFieldNameFromFieldOcc recUpdFields
+  fmap (fmap mkRegularField . fromGenLocated) recUpdFields
 collectFields GHC.OverloadedRecUpdFields {..} =
-  collectFieldsWith mkFieldNameFromFieldLabelStrings olRecUpdFields
+  fmap (fmap mkOverloadedField . fromGenLocated) olRecUpdFields
 #elif MIN_VERSION_ghc_lib_parser(9, 6, 1)
 collectFields GHC.RegularRecUpdFields {..} =
-  collectFieldsWith mkFieldNameFromAmbiguousFieldOcc recUpdFields
+  fmap (fmap mkRegularField . fromGenLocated) recUpdFields
 collectFields GHC.OverloadedRecUpdFields {..} =
-  collectFieldsWith mkFieldNameFromFieldLabelStrings olRecUpdFields
+  fmap (fmap mkOverloadedField . fromGenLocated) olRecUpdFields
 #else
-collectFields = collectFieldsWith mkFieldNameFromFieldOcc . either id id
+collectFields = fmap (fmap mkRegularField . fromGenLocated) . either id id
 #endif
-mkField ::
-     (GHC.XRec GHC.GhcPs label -> WithComments FieldName)
-  -> GHC.HsFieldBind (GHC.XRec GHC.GhcPs label) (GHC.LHsExpr GHC.GhcPs)
-  -> Field
-mkField wrapLabel GHC.HsFieldBind {..} =
+
+#if MIN_VERSION_ghc_lib_parser(9, 12, 1)
+mkRegularField ::
+     GHC.HsFieldBind (GHC.LFieldOcc GHC.GhcPs) (GHC.LHsExpr GHC.GhcPs) -> Field
+mkRegularField GHC.HsFieldBind {..} =
   Field
-    { fieldName = wrapLabel hfbLHS
+    { fieldName = mkFieldNameFromFieldOcc <$> fromGenLocated hfbLHS
     , value =
         if hfbPun
           then Nothing
           else Just $ mkExpression <$> fromGenLocated hfbRHS
     }
+
+mkOverloadedField ::
+     GHC.HsFieldBind (GHC.LFieldLabelStrings GHC.GhcPs) (GHC.LHsExpr GHC.GhcPs)
+  -> Field
+mkOverloadedField GHC.HsFieldBind {..} =
+  Field
+    { fieldName = mkFieldNameFromFieldLabelStrings <$> fromGenLocated hfbLHS
+    , value =
+        if hfbPun
+          then Nothing
+          else Just $ mkExpression <$> fromGenLocated hfbRHS
+    }
+#elif MIN_VERSION_ghc_lib_parser(9, 6, 1)
+mkRegularField ::
+     GHC.HsFieldBind (GHC.LAmbiguousFieldOcc GHC.GhcPs) (GHC.LHsExpr GHC.GhcPs)
+  -> Field
+mkRegularField GHC.HsFieldBind {..} =
+  Field
+    { fieldName = mkFieldNameFromAmbiguousFieldOcc <$> fromGenLocated hfbLHS
+    , value =
+        if hfbPun
+          then Nothing
+          else Just $ mkExpression <$> fromGenLocated hfbRHS
+    }
+
+mkOverloadedField ::
+     GHC.HsFieldBind (GHC.LFieldLabelStrings GHC.GhcPs) (GHC.LHsExpr GHC.GhcPs)
+  -> Field
+mkOverloadedField GHC.HsFieldBind {..} =
+  Field
+    { fieldName = mkFieldNameFromFieldLabelStrings <$> fromGenLocated hfbLHS
+    , value =
+        if hfbPun
+          then Nothing
+          else Just $ mkExpression <$> fromGenLocated hfbRHS
+    }
+#else
+mkRegularField ::
+     GHC.HsFieldBind (GHC.LFieldOcc GHC.GhcPs) (GHC.LHsExpr GHC.GhcPs) -> Field
+mkRegularField GHC.HsFieldBind {..} =
+  Field
+    { fieldName = mkFieldNameFromFieldOcc <$> fromGenLocated hfbLHS
+    , value =
+        if hfbPun
+          then Nothing
+          else Just $ mkExpression <$> fromGenLocated hfbRHS
+    }
+#endif


### PR DESCRIPTION
## Summary
Specialize comment handling for record update fields by removing the generic field collection path and handling regular and overloaded fields separately.

## Testing
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin stack run -- --validate app/**/*.hs src/**/*.hs tests/**/*.hs
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin hlint .
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin stack test
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin cabal test -j -w /home/hiroki/.ghcup/ghc/9.6.7/bin/ghc
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin cabal test -j -w /home/hiroki/.ghcup/ghc/9.8.4/bin/ghc
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin cabal test -j -w /home/hiroki/.ghcup/ghc/9.10.3/bin/ghc
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin cabal test -j -w /home/hiroki/.ghcup/ghc/9.12.4/bin/ghc
- PATH=/home/hiroki/.ghcup/bin:/home/hiroki/.codex/tmp/arg0/codex-arg0Dchfgn:/home/hiroki/.opam/default/bin:/home/hiroki/.npm-global/bin:/home/hiroki/.jenv/bin:/home/hiroki/.local/bin:/home/hiroki/.cargo/bin:/home/hiroki/.ghcup/bin:/home/hiroki/.fly/bin:/opt/homebrew/bin:/home/hiroki/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/opt/bin:/usr/lib/llvm/21/bin:/usr/lib/llvm/18/bin:/opt/android-sdk/cmdline-tools/latest/bin:/etc/eselect/wine/bin cabal test -j -w /home/hiroki/.ghcup/ghc/9.14.1/bin/ghc