### PR TITLE
refactor: migrate family type argument nodes

### DIFF
--- a/hindent.cabal
+++ b/hindent.cabal
@@ -136,6 +136,8 @@ library
       HIndent.Ast.Role
       HIndent.Ast.Statement
       HIndent.Ast.Type
+      HIndent.Ast.Type.Argument
+      HIndent.Ast.Type.Argument.Collection
       HIndent.Ast.Type.Bang
       HIndent.Ast.Type.Forall
       HIndent.Ast.Type.ImplicitParameterName

--- a/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Data.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, CPP #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Data
   ( DataFamilyInstance
@@ -10,33 +10,28 @@ import HIndent.Ast.Declaration.Data.Body
 import HIndent.Ast.Declaration.Data.NewOrData
 import HIndent.Ast.Name.Prefix
 import HIndent.Ast.NodeComments
+import HIndent.Ast.Type.Argument.Collection
 import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
-#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+
 data DataFamilyInstance = DataFamilyInstance
   { newOrData :: NewOrData
   , name :: WithComments PrefixName
-  , types :: GHC.HsFamEqnPats GHC.GhcPs
+  , types :: TypeArgumentCollection
   , body :: DataBody
   }
-#else
-data DataFamilyInstance = DataFamilyInstance
-  { newOrData :: NewOrData
-  , name :: WithComments PrefixName
-  , types :: GHC.HsTyPats GHC.GhcPs
-  , body :: DataBody
-  }
-#endif
+
 instance CommentExtraction DataFamilyInstance where
   nodeComments DataFamilyInstance {} = NodeComments [] [] []
 
 instance Pretty DataFamilyInstance where
   pretty' DataFamilyInstance {..} = do
     spaced
-      $ pretty newOrData : string "instance" : pretty name : fmap pretty types
+      $ [pretty newOrData, string "instance", pretty name]
+          <> [pretty types | hasTypeArguments types]
     pretty body
 
 mkDataFamilyInstance ::
@@ -45,5 +40,5 @@ mkDataFamilyInstance GHC.FamEqn {..} = DataFamilyInstance {..}
   where
     newOrData = mkNewOrData feqn_rhs
     name = fromGenLocated $ fmap mkPrefixName feqn_tycon
-    types = feqn_pats
+    types = mkTypeArgumentCollection feqn_pats
     body = mkDataBody feqn_rhs

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, CPP #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Type
   ( TypeFamilyInstance
@@ -8,30 +8,27 @@ module HIndent.Ast.Declaration.Instance.Family.Type
 import HIndent.Ast.Name.Prefix
 import HIndent.Ast.NodeComments
 import HIndent.Ast.Type
+import HIndent.Ast.Type.Argument.Collection
 import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
-#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+
 data TypeFamilyInstance = TypeFamilyInstance
   { name :: WithComments PrefixName
-  , types :: GHC.HsFamEqnPats GHC.GhcPs
+  , types :: TypeArgumentCollection
   , bind :: WithComments Type
   }
-#else
-data TypeFamilyInstance = TypeFamilyInstance
-  { name :: WithComments PrefixName
-  , types :: GHC.HsTyPats GHC.GhcPs
-  , bind :: WithComments Type
-  }
-#endif
+
 instance CommentExtraction TypeFamilyInstance where
   nodeComments TypeFamilyInstance {} = NodeComments [] [] []
 
 instance Pretty TypeFamilyInstance where
   pretty' TypeFamilyInstance {..} = do
-    spaced $ string "type instance" : pretty name : fmap pretty types
+    spaced
+      $ [string "type instance", pretty name]
+          <> [pretty types | hasTypeArguments types]
     string " = "
     pretty bind
 
@@ -40,6 +37,6 @@ mkTypeFamilyInstance GHC.TyFamInstD {GHC.tfid_inst = GHC.TyFamInstDecl {GHC.tfid
   Just $ TypeFamilyInstance {..}
   where
     name = fromGenLocated $ fmap mkPrefixName feqn_tycon
-    types = feqn_pats
+    types = mkTypeArgumentCollection feqn_pats
     bind = mkType <$> fromGenLocated feqn_rhs
 mkTypeFamilyInstance _ = Nothing

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated.hs
@@ -1,24 +1,41 @@
-{-# LANGUAGE RecordWildCards, CPP #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Type.Associated
   ( AssociatedType
   , mkAssociatedType
   ) where
 
+import HIndent.Ast.Name.Prefix
 import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.Type.Argument.Collection
+import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
 
-newtype AssociatedType =
-  AssociatedType (GHC.FamEqn GHC.GhcPs (GHC.LocatedA (GHC.HsType GHC.GhcPs)))
+data AssociatedType = AssociatedType
+  { name :: WithComments PrefixName
+  , types :: TypeArgumentCollection
+  , bind :: WithComments Type
+  }
 
 instance CommentExtraction AssociatedType where
-  nodeComments (AssociatedType _) = NodeComments [] [] []
+  nodeComments AssociatedType {} = NodeComments [] [] []
 
 instance Pretty AssociatedType where
-  pretty' (AssociatedType equation) = string "type " >> pretty equation
+  pretty' AssociatedType {..} = spaced [lhs, string "=", pretty bind]
+    where
+      lhs =
+        spaced
+          $ [string "type", pretty name]
+              <> [pretty types | hasTypeArguments types]
 
 mkAssociatedType :: GHC.TyFamInstDecl GHC.GhcPs -> AssociatedType
-mkAssociatedType GHC.TyFamInstDecl {..} = AssociatedType tfid_eqn
+mkAssociatedType GHC.TyFamInstDecl {GHC.tfid_eqn = GHC.FamEqn {..}} =
+  AssociatedType
+    { name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    , types = mkTypeArgumentCollection feqn_pats
+    , bind = mkType <$> fromGenLocated feqn_rhs
+    }

--- a/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
+++ b/src/HIndent/Ast/Declaration/Instance/Family/Type/Associated/Default.hs
@@ -1,27 +1,41 @@
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE CPP #-}
 
 module HIndent.Ast.Declaration.Instance.Family.Type.Associated.Default
   ( AssociatedTypeDefault
   , mkAssociatedTypeDefault
   ) where
 
+import HIndent.Ast.Name.Prefix
 import HIndent.Ast.NodeComments
+import HIndent.Ast.Type
+import HIndent.Ast.Type.Argument.Collection
+import HIndent.Ast.WithComments
 import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
 import {-# SOURCE #-} HIndent.Pretty
 import HIndent.Pretty.Combinators
 import HIndent.Pretty.NodeComments
 
-newtype AssociatedTypeDefault =
-  AssociatedTypeDefault
-    (GHC.FamEqn GHC.GhcPs (GHC.LocatedA (GHC.HsType GHC.GhcPs)))
+data AssociatedTypeDefault = AssociatedTypeDefault
+  { name :: WithComments PrefixName
+  , types :: TypeArgumentCollection
+  , bind :: WithComments Type
+  }
 
 instance CommentExtraction AssociatedTypeDefault where
-  nodeComments (AssociatedTypeDefault _) = NodeComments [] [] []
+  nodeComments AssociatedTypeDefault {} = NodeComments [] [] []
 
 instance Pretty AssociatedTypeDefault where
-  pretty' (AssociatedTypeDefault equation) =
-    string "type instance " >> pretty equation
+  pretty' AssociatedTypeDefault {..} = spaced [lhs, string "=", pretty bind]
+    where
+      lhs =
+        spaced
+          $ [string "type instance", pretty name]
+              <> [pretty types | hasTypeArguments types]
 
 mkAssociatedTypeDefault :: GHC.TyFamInstDecl GHC.GhcPs -> AssociatedTypeDefault
-mkAssociatedTypeDefault GHC.TyFamInstDecl {..} = AssociatedTypeDefault tfid_eqn
+mkAssociatedTypeDefault GHC.TyFamInstDecl {GHC.tfid_eqn = GHC.FamEqn {..}} =
+  AssociatedTypeDefault
+    { name = fromGenLocated $ fmap mkPrefixName feqn_tycon
+    , types = mkTypeArgumentCollection feqn_pats
+    , bind = mkType <$> fromGenLocated feqn_rhs
+    }

--- a/src/HIndent/Ast/Type/Argument.hs
+++ b/src/HIndent/Ast/Type/Argument.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module HIndent.Ast.Type.Argument
+  ( TypeArgument
+  , mkTypeArgument
+  ) where
+
+import HIndent.Ast.Type (Type, mkType)
+import HIndent.Ast.WithComments
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import {-# SOURCE #-} HIndent.Pretty
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+
+data TypeArgument
+  = TypeArgument
+      { argType :: WithComments Type
+      }
+  | KindArgument
+      { argKind :: WithComments Type
+      }
+
+instance CommentExtraction TypeArgument where
+  nodeComments TypeArgument {..} = nodeComments argType
+  nodeComments KindArgument {..} = nodeComments argKind
+
+instance Pretty TypeArgument where
+  pretty' TypeArgument {..} = pretty argType
+  pretty' KindArgument {..} = string "@" >> pretty argKind
+
+mkTypeArgument ::
+     GHC.HsArg GHC.GhcPs (GHC.LHsType GHC.GhcPs) (GHC.LHsType GHC.GhcPs)
+  -> Maybe TypeArgument
+#if MIN_VERSION_ghc_lib_parser(9, 10, 1)
+mkTypeArgument (GHC.HsValArg _ argType) =
+  Just TypeArgument {argType = mkType <$> fromGenLocated argType}
+mkTypeArgument (GHC.HsTypeArg _ argKind) =
+  Just KindArgument {argKind = mkType <$> fromGenLocated argKind}
+mkTypeArgument GHC.HsArgPar {} = Nothing
+#else
+mkTypeArgument (GHC.HsValArg argType) =
+  Just TypeArgument {argType = mkType <$> fromGenLocated argType}
+mkTypeArgument (GHC.HsTypeArg _ argKind) =
+  Just KindArgument {argKind = mkType <$> fromGenLocated argKind}
+mkTypeArgument GHC.HsArgPar {} = Nothing
+#endif

--- a/src/HIndent/Ast/Type/Argument/Collection.hs
+++ b/src/HIndent/Ast/Type/Argument/Collection.hs
@@ -1,0 +1,30 @@
+module HIndent.Ast.Type.Argument.Collection
+  ( TypeArgumentCollection
+  , hasTypeArguments
+  , mkTypeArgumentCollection
+  ) where
+
+import Data.Maybe (mapMaybe)
+import HIndent.Ast.Type.Argument
+import qualified HIndent.GhcLibParserWrapper.GHC.Hs as GHC
+import {-# SOURCE #-} HIndent.Pretty
+import HIndent.Pretty.Combinators
+import HIndent.Pretty.NodeComments
+
+newtype TypeArgumentCollection =
+  TypeArgumentCollection [TypeArgument]
+
+instance CommentExtraction TypeArgumentCollection where
+  nodeComments (TypeArgumentCollection arguments) =
+    mconcat $ fmap nodeComments arguments
+
+instance Pretty TypeArgumentCollection where
+  pretty' (TypeArgumentCollection arguments) = spaced $ fmap pretty arguments
+
+mkTypeArgumentCollection ::
+     [GHC.HsArg GHC.GhcPs (GHC.LHsType GHC.GhcPs) (GHC.LHsType GHC.GhcPs)]
+  -> TypeArgumentCollection
+mkTypeArgumentCollection = TypeArgumentCollection . mapMaybe mkTypeArgument
+
+hasTypeArguments :: TypeArgumentCollection -> Bool
+hasTypeArguments (TypeArgumentCollection arguments) = not $ null arguments


### PR DESCRIPTION
## Summary
- introduce  and 
- use them in family instance declarations instead of storing  directly
- keep the change scoped to family instance nodes

## Verification
- stack run -- --validate app/**/*.hs src/**/*.hs tests/**/*.hs
- hlint .
- stack test
- cabal test -j -w /home/hiroki/.ghcup/ghc/9.6.7/bin/ghc
- cabal test -j -w /home/hiroki/.ghcup/ghc/9.8.4/bin/ghc
- cabal test -j -w /home/hiroki/.ghcup/ghc/9.10.3/bin/ghc
- cabal test -j -w /home/hiroki/.ghcup/ghc/9.12.4/bin/ghc
- cabal test -j -w /home/hiroki/.ghcup/ghc/9.14.1/bin/ghc